### PR TITLE
Add return statement for Subscribe method in the Observer.cpp

### DIFF
--- a/Chapter05/Source_Code/Observer.cpp
+++ b/Chapter05/Source_Code/Observer.cpp
@@ -26,7 +26,7 @@ class EventSourceValueSubject{
        sinks.clear();
    }
    bool Subscribe( EventSourceValueObserver<T> *sink )
-   { sinks.push_back(sink);}
+   { sinks.push_back(sink); return true;}
 
    void NotifyAll() {
       for (auto sink : sinks) { sink->Update(State); }


### PR DESCRIPTION
In accordance with the [BookExprEval.cpp](https://github.com/PacktPublishing/CPP-Reactive-Programming/blob/9f519f8f4ed47a4a16ef360afe2052924c1914a8/Chapter05/Source_Code/BookExprEval.cpp#L262)